### PR TITLE
Add mob protection on player death

### DIFF
--- a/src/main/java/de/nikey/spawnProtection/Listener/ProtectionListener.java
+++ b/src/main/java/de/nikey/spawnProtection/Listener/ProtectionListener.java
@@ -63,9 +63,7 @@ public class ProtectionListener implements Listener {
             manager.startProtection(player, true);
             SpawnProtection.getMobProtectionManager().startFirstJoinProtection(player);
         } else if (manager.hasProtection(player.getUniqueId())) {
-            if (!SpawnProtection.getProtectionManager().isContinueOffline()) {
-                manager.resumeProtection(player);
-            }
+            manager.resumeProtection(player);
         }
     }
 

--- a/src/main/java/de/nikey/spawnProtection/Listener/ProtectionListener.java
+++ b/src/main/java/de/nikey/spawnProtection/Listener/ProtectionListener.java
@@ -40,6 +40,8 @@ public class ProtectionListener implements Listener {
             manager.startProtection(player, false);
         }
 
+        SpawnProtection.getMobProtectionManager().startDeathProtection(player);
+
         UUID deadPlayerUUID = player.getUniqueId();
 
         pendingConfirmations.entrySet().removeIf(entry ->

--- a/src/main/java/de/nikey/spawnProtection/Managers/MobProtectionManager.java
+++ b/src/main/java/de/nikey/spawnProtection/Managers/MobProtectionManager.java
@@ -42,12 +42,16 @@ public class MobProtectionManager {
         return plugin.getConfig().getString("mob-protection.protection-display", "bossbar");
     }
 
-    /**
-     * Grants the configured first-join mob protection if the feature is enabled.
-     */
     public void startFirstJoinProtection(Player player) {
         if (!isEnabled()) return;
         int seconds = plugin.getConfig().getInt("mob-protection.first-join-seconds", 300);
+        grantProtection(player, seconds, true);
+    }
+
+    public void startDeathProtection(Player player) {
+        if (!isEnabled()) return;
+        if (!plugin.getConfig().getBoolean("mob-protection.on-death", false)) return;
+        int seconds = plugin.getConfig().getInt("mob-protection.on-death-seconds", 300);
         grantProtection(player, seconds, true);
     }
 

--- a/src/main/java/de/nikey/spawnProtection/Managers/ProtectionManager.java
+++ b/src/main/java/de/nikey/spawnProtection/Managers/ProtectionManager.java
@@ -312,6 +312,11 @@ public class ProtectionManager {
             return;
         }
 
+        if (timers.containsKey(uuid)) {
+            timers.get(uuid).cancel();
+            timers.remove(uuid);
+        }
+
         String displayMode = plugin.getConfig().getString("protection.protection-display", "actionbar");
         BossBar bar = bossBars.remove(player.getUniqueId());
         if (!player.isOnline())return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,8 @@ protection:
 mob-protection: # Protects players from mobs/monsters for a while after they join the server for the first time
   enabled: true
   first-join-seconds: 300 # In seconds. Time after the first join during which mobs/monsters can't attack the player
+  on-death: false # If true, mob protection is also granted when a player dies
+  on-death-seconds: 300 # In seconds. Duration of mob protection granted on death
   protection-display: bossbar # How the remaining mob protection is shown as a cooldown. Possible values: actionbar, bossbar
 
 tab-list:


### PR DESCRIPTION
## Summary
This PR extends the mob protection feature to grant protection to players when they die, in addition to the existing first-join protection. A new configuration option allows servers to enable/disable this feature and customize the protection duration.

## Key Changes
- Added `startDeathProtection()` method to `MobProtectionManager` to handle mob protection grants on player death
- Integrated death protection into the `ProtectionListener.onDeath()` event handler
- Added configuration options `mob-protection.on-death` and `mob-protection.on-death-seconds` to control the feature
- Fixed `resumeProtection()` in `ProtectionManager` to properly cancel any existing timers before resuming protection, preventing timer conflicts
- Simplified the `onJoin()` logic in `ProtectionListener` by removing the `isContinueOffline()` check, ensuring protection is always resumed when a player rejoins with existing protection

## Implementation Details
- Death protection respects the same enable/disable flag as first-join protection
- The feature is disabled by default (`on-death: false`) with a configurable duration (default 300 seconds)
- Protection announcement behavior is consistent with first-join protection
- Timer cleanup in `resumeProtection()` prevents duplicate/conflicting protection timers when players rejoin

https://claude.ai/code/session_01YEPN5RTjGub2KKypRV3DtQ