### PR TITLE
Add configurable potion effects on player death

### DIFF
--- a/src/main/java/de/nikey/spawnProtection/Listener/ProtectionListener.java
+++ b/src/main/java/de/nikey/spawnProtection/Listener/ProtectionListener.java
@@ -16,6 +16,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,6 +48,11 @@ public class ProtectionListener implements Listener {
         pendingConfirmations.entrySet().removeIf(entry ->
                 entry.getKey().equals(deadPlayerUUID) || entry.getValue().equals(deadPlayerUUID)
         );
+    }
+
+    @EventHandler
+    public void onRespawn(PlayerRespawnEvent event) {
+        SpawnProtection.getDeathEffectsManager().applyDeathEffects(event.getPlayer());
     }
 
     @EventHandler

--- a/src/main/java/de/nikey/spawnProtection/Listener/ProtectionListener.java
+++ b/src/main/java/de/nikey/spawnProtection/Listener/ProtectionListener.java
@@ -52,6 +52,7 @@ public class ProtectionListener implements Listener {
 
     @EventHandler
     public void onRespawn(PlayerRespawnEvent event) {
+        if (event.getRespawnReason() != PlayerRespawnEvent.RespawnReason.DEATH) return;
         SpawnProtection.getDeathEffectsManager().applyDeathEffects(event.getPlayer());
     }
 

--- a/src/main/java/de/nikey/spawnProtection/Managers/DeathEffectsManager.java
+++ b/src/main/java/de/nikey/spawnProtection/Managers/DeathEffectsManager.java
@@ -1,0 +1,65 @@
+package de.nikey.spawnProtection.Managers;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Grants configurable potion effects to a player when they die,
+ * e.g. as a temporary debuff/buff after respawning.
+ */
+public class DeathEffectsManager {
+
+    private final Plugin plugin;
+
+    public DeathEffectsManager(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public boolean isEnabled() {
+        return plugin.getConfig().getBoolean("death-effects.enabled", false);
+    }
+
+    public void applyDeathEffects(Player player) {
+        if (!isEnabled()) return;
+
+        ConfigurationSection effectsSection = plugin.getConfig().getConfigurationSection("death-effects.effects");
+        if (effectsSection == null) return;
+
+        for (String key : effectsSection.getKeys(false)) {
+            ConfigurationSection effectSection = effectsSection.getConfigurationSection(key);
+            if (effectSection == null) continue;
+
+            if (!effectSection.getBoolean("enabled", true)) continue;
+
+            String typeName = effectSection.getString("type");
+            if (typeName == null) {
+                plugin.getLogger().warning("death-effects.effects." + key + " is missing a 'type', skipping.");
+                continue;
+            }
+
+            PotionEffectType type = PotionEffectType.getByName(typeName.toUpperCase());
+            if (type == null) {
+                plugin.getLogger().warning("Unknown potion effect type '" + typeName + "' in death-effects.effects." + key);
+                continue;
+            }
+
+            int durationSeconds = effectSection.getInt("duration-seconds", 30);
+            int amplifier = effectSection.getInt("amplifier", 0);
+            boolean ambient = effectSection.getBoolean("ambient", true);
+            boolean particles = effectSection.getBoolean("particles", true);
+            boolean icon = effectSection.getBoolean("icon", true);
+
+            player.addPotionEffect(new PotionEffect(
+                    type,
+                    durationSeconds * 20,
+                    amplifier,
+                    ambient,
+                    particles,
+                    icon
+            ));
+        }
+    }
+}

--- a/src/main/java/de/nikey/spawnProtection/SpawnProtection.java
+++ b/src/main/java/de/nikey/spawnProtection/SpawnProtection.java
@@ -4,6 +4,7 @@ import de.nikey.spawnProtection.Commands.SpawnProtectionCommand;
 import de.nikey.spawnProtection.Listener.ProtectionListener;
 import de.nikey.spawnProtection.Listener.ProximityWatcher;
 import de.nikey.spawnProtection.Managers.DailyProtectionManager;
+import de.nikey.spawnProtection.Managers.DeathEffectsManager;
 import de.nikey.spawnProtection.Managers.MobProtectionManager;
 import de.nikey.spawnProtection.Managers.ProtectionManager;
 import de.nikey.spawnProtection.Managers.TodayPlaytimeManager;
@@ -25,6 +26,7 @@ public final class SpawnProtection extends JavaPlugin {
     private static MobProtectionManager mobProtectionManager;
     private static DailyProtectionManager dailyProtectionManager;
     private static TodayPlaytimeManager todayPlaytimeManager;
+    private static DeathEffectsManager deathEffectsManager;
 
     public static boolean hasTrustEnabled = false;
     public static boolean hasBuffSMPEnabled = false;
@@ -37,6 +39,7 @@ public final class SpawnProtection extends JavaPlugin {
         mobProtectionManager = new MobProtectionManager(this);
         dailyProtectionManager = new DailyProtectionManager(this);
         todayPlaytimeManager = new TodayPlaytimeManager(this);
+        deathEffectsManager = new DeathEffectsManager(this);
         getCommand("spawnprotection").setExecutor(new SpawnProtectionCommand());
         getCommand("spawnprotection").setTabCompleter(new SpawnProtectionCommand());
         new ProtectionListener(protectionManager);
@@ -111,6 +114,10 @@ public final class SpawnProtection extends JavaPlugin {
 
     public static MobProtectionManager getMobProtectionManager() {
         return mobProtectionManager;
+    }
+
+    public static DeathEffectsManager getDeathEffectsManager() {
+        return deathEffectsManager;
     }
 
     public static SpawnProtection getPlugin() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,7 +31,7 @@ death-effects: # Gives players potion effects when they die (applied on respawn)
   effects:
     weakness:
       enabled: true
-      type: WEAKNESS # Any valid Bukkit PotionEffectType, e.g. WEAKNESS, SLOW, BLINDNESS, REGENERATION...
+      type: WEAKNESS # Any valid Bukkit PotionEffectType, e.g. WEAKNESS, SLOWNESS, BLINDNESS, REGENERATION...
       duration-seconds: 30
       amplifier: 0 # Effect level, 0 = level 1
       ambient: true # Whether the effect uses the translucent particle style
@@ -39,7 +39,7 @@ death-effects: # Gives players potion effects when they die (applied on respawn)
       icon: true # Whether the effect icon is shown in the inventory
     slowness:
       enabled: false
-      type: SLOW
+      type: SLOWNESS
       duration-seconds: 30
       amplifier: 1
       ambient: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,26 @@ proximity-detection:
   radius: 52
   min-time-seconds: 120
 
+death-effects: # Gives players potion effects when they die (applied on respawn)
+  enabled: false
+  effects:
+    weakness:
+      enabled: true
+      type: WEAKNESS # Any valid Bukkit PotionEffectType, e.g. WEAKNESS, SLOW, BLINDNESS, REGENERATION...
+      duration-seconds: 30
+      amplifier: 0 # Effect level, 0 = level 1
+      ambient: true # Whether the effect uses the translucent particle style
+      particles: true # Whether particles are shown at all
+      icon: true # Whether the effect icon is shown in the inventory
+    slowness:
+      enabled: false
+      type: SLOW
+      duration-seconds: 30
+      amplifier: 1
+      ambient: true
+      particles: true
+      icon: true
+
 messages:
   protection-ended: "&aYour spawn protection has ended."
   protected-nearby: "&eYou are too close to players who could harm you!"


### PR DESCRIPTION
## Summary
This PR introduces a new `DeathEffectsManager` that applies configurable potion effects to players when they respawn after dying. This allows server administrators to apply temporary debuffs or buffs to players as part of the spawn protection system.

## Key Changes
- **New `DeathEffectsManager` class**: Manages the application of potion effects on player death/respawn
  - Reads effect configurations from `config.yml`
  - Validates potion effect types and logs warnings for invalid configurations
  - Applies effects with customizable duration, amplifier, and visual settings
  
- **Updated `ProtectionListener`**: Added `onRespawn()` event handler to trigger death effects when players respawn from death

- **Updated `SpawnProtection` main class**: Instantiates and exposes the new `DeathEffectsManager` via static getter

- **Enhanced `config.yml`**: Added new `death-effects` configuration section with:
  - Global enable/disable toggle
  - Per-effect enable/disable flags
  - Customizable effect type, duration, amplifier, and visual options
  - Example configurations for WEAKNESS and SLOWNESS effects

## Implementation Details
- Effects are only applied when respawning from death (checked via `RespawnReason.DEATH`)
- Configuration is flexible and extensible - administrators can add any number of potion effects
- Invalid effect types are logged as warnings without breaking the plugin
- All potion effect parameters (ambient, particles, icon) are configurable per effect
- Duration is specified in seconds and automatically converted to ticks (×20)

https://claude.ai/code/session_01HtttkmdhTeZoNPifwVH6xo